### PR TITLE
Introduces hack to pass variabels by reference

### DIFF
--- a/classes/MockCallHelper.php
+++ b/classes/MockCallHelper.php
@@ -23,14 +23,16 @@ class MockCallHelper
      * @return mixed The result of the called function.
      * @see Mock::define()
      */
-    public static function call(
-        $functionName,
-        $canonicalFunctionName,
-        array $arguments
-    ) {
+    public static function call($functionName, $canonicalFunctionName, &$arguments)
+    {
         $registry = MockRegistry::getInstance();
         $mock     = $registry->getMock($canonicalFunctionName);
 
+        foreach ($arguments as $key => $arg) {
+            if ($arg === Mock::DEFAULT_ARGUMENT) {
+                unset($arguments[$key]);
+            }
+        }
         if (empty($mock)) {
             // call the built-in function if the mock was not enabled.
             return call_user_func_array($functionName, $arguments);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <phpunit
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php">
+         bootstrap="tests/bootstrap.php">
     <testsuite>
         <directory>tests</directory>
     </testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @author  Andreas Heigl<andreas@heigl.org>
+ * @license http://www.wtfpl.net/txt/copying/ WTFPL
+ * @since   08.02.15
+ */
+require_once __DIR__ . '/../vendor/autoload.php';
+
+require_once __DIR__ . '/global_functions.php';

--- a/tests/global_functions.php
+++ b/tests/global_functions.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @author  Andreas Heigl<andreas@heigl.org>
+ * @license http://www.wtfpl.net/txt/copying/ WTFPL
+ * @since   08.02.15
+ */
+function emptyFunc()
+{
+    // Empty Function as required by codesniffer instead of an empty anonymous
+    // function
+}

--- a/tests/phpunit/MockDisablerTest.php
+++ b/tests/phpunit/MockDisablerTest.php
@@ -24,11 +24,11 @@ class MockDisablerTest extends \PHPUnit_Framework_TestCase
     {
         $min = new Mock(__NAMESPACE__, "min", "max");
         $min->enable();
-        $this->assertEquals(9, min(1, 9));
+        $this->assertEquals(9, min(array(1, 9)));
         
         $disabler = new MockDisabler($min);
         $disabler->endTest($this, 1);
         
-        $this->assertEquals(1, min(1, 9));
+        $this->assertEquals(1, min(array(1, 9)));
     }
 }


### PR DESCRIPTION
When mocking system-functions that expect variables to be passed by reference, this hack allows to do so. This might f.i. help mocking sort-functions or ```exec``` or ```passthru```