### PR TITLE
Add date() mock to SleepEnvironmentBuilder.

### DIFF
--- a/classes/SleepEnvironmentBuilder.php
+++ b/classes/SleepEnvironmentBuilder.php
@@ -38,17 +38,17 @@ use malkusch\phpmock\functions\UsleepFunction;
  */
 class SleepEnvironmentBuilder
 {
-    
+
     /**
      * @var string The namespace for the mock environment.
      */
     private $namespace;
-    
+
     /**
      * @var mixed the timestamp.
      */
     private $timestamp;
-    
+
     /**
      * Sets the namespace for the mock environment.
      *
@@ -60,7 +60,7 @@ class SleepEnvironmentBuilder
         $this->namespace = $namespace;
         return $this;
     }
-    
+
     /**
      * Sets the mocked timestamp.
      *
@@ -76,7 +76,7 @@ class SleepEnvironmentBuilder
         $this->timestamp = $timestamp;
         return $this;
     }
-    
+
     /**
      * Builds a sleep(), usleep(), time() and microtime() mock environment.
      *
@@ -85,33 +85,38 @@ class SleepEnvironmentBuilder
     public function build()
     {
         $environment = new MockEnvironment();
-        
+
         $builder = new MockBuilder();
         $builder->setNamespace($this->namespace);
-        
+
         // microtime() mock
         $microtime = new FixedMicrotimeFunction($this->timestamp);
         $builder->setName("microtime")
                 ->setFunctionProvider($microtime);
         $environment->addMock($builder->build());
-        
+
         // time() mock
         $builder->setName("time")
                 ->setFunction([$microtime, "getTime"]);
         $environment->addMock($builder->build());
-        
+
+        // date() mock
+        $builder->setName("date")
+                ->setFunction([$microtime, "getDate"]);
+        $environment->addMock($builder->build());
+
         $incrementables = [$microtime];
-        
+
         // sleep() mock
         $builder->setName("sleep")
                 ->setFunctionProvider(new SleepFunction($incrementables));
         $environment->addMock($builder->build());
-        
+
         // usleep() mock
         $builder->setName("usleep")
                 ->setFunctionProvider(new UsleepFunction($incrementables));
         $environment->addMock($builder->build());
-        
+
         return $environment;
     }
 }

--- a/classes/functions/FixedMicrotimeFunction.php
+++ b/classes/functions/FixedMicrotimeFunction.php
@@ -11,12 +11,12 @@ namespace malkusch\phpmock\functions;
  */
 class FixedMicrotimeFunction implements FunctionProvider, Incrementable
 {
-    
+
     /**
      * @var string the timestamp in PHP's microtime() string format.
      */
     private $timestamp;
-    
+
     /**
      * Set the timestamp.
      *
@@ -26,21 +26,21 @@ class FixedMicrotimeFunction implements FunctionProvider, Incrementable
     {
         if (is_null($timestamp)) {
             $this->setMicrotime(\microtime());
-            
+
         } elseif (is_string($timestamp)) {
             $this->setMicrotime($timestamp);
-            
+
         } elseif (is_numeric($timestamp)) {
             $this->setMicrotimeAsFloat($timestamp);
-            
+
         } else {
             throw new \InvalidArgumentException(
                 "Timestamp parameter is invalid type."
             );
-            
+
         }
     }
-    
+
     /**
      * Returns this object as a callable for the mock function.
      *
@@ -71,7 +71,7 @@ class FixedMicrotimeFunction implements FunctionProvider, Incrementable
         $converter = new MicrotimeConverter();
         $this->timestamp = $converter->convertFloatToString($timestamp);
     }
-    
+
     /**
      * Returns the microtime.
      *
@@ -83,13 +83,13 @@ class FixedMicrotimeFunction implements FunctionProvider, Incrementable
         if ($get_as_float) {
             $converter = new MicrotimeConverter();
             return $converter->convertStringToFloat($this->timestamp);
-            
+
         } else {
             return $this->timestamp;
-            
+
         }
     }
-    
+
     /**
      * Returns the time without the microseconds.
      *
@@ -98,6 +98,23 @@ class FixedMicrotimeFunction implements FunctionProvider, Incrementable
     public function getTime()
     {
         return (int) $this->getMicrotime(true);
+    }
+
+    /**
+     * Returns a formatted date string.
+     *
+     * @param string $format The format of the outputted date string
+     * @param int $timestamp The optional timestamp parameter as an integer timestamp. Default is $this->getTime().
+     * @return bool|string Returns a formatted date string. If a non-numeric value is used for timestamp,
+     * FALSE is returned and an E_WARNING level error is emitted.
+     * @see \date()
+     */
+    public function getDate($format, $timestamp = null)
+    {
+        if ($timestamp === null) {
+            $timestamp = $this->getTime();
+        }
+        return \date($format, $timestamp);
     }
 
     public function increment($increment)


### PR DESCRIPTION
Hi Markus,

I added a `date()` mock into `SleepEnvironmentBuilder` to complete list of time functions. I needed it for my project's tests :-)

Regards,
Geoffroy
